### PR TITLE
Configure iron-sight camera for R700

### DIFF
--- a/R700/config.cpp
+++ b/R700/config.cpp
@@ -122,12 +122,14 @@ class cfgWeapons
 			dispersion=0.0015;
 			magazineSlot="magazine";
 		};
-		class OpticsInfo: OpticsInfoRifle
-		{
-			modelOptics="-";
-			distanceZoomMin=100;
-			distanceZoomMax=100;
-		};
+               class OpticsInfo: OpticsInfoRifle
+               {
+                       memoryPointCamera="eye"; // camera anchor point
+                       cameraDir="cameraDir"; // camera direction
+                       modelOptics="-"; // disable optic model
+                       distanceZoomMin=100; // minimum zoom distance
+                       distanceZoomMax=100; // maximum zoom distance
+               };
 		class InventorySlotsOffsets
 		{
 			class Shoulder


### PR DESCRIPTION
## Summary
- add memoryPointCamera and cameraDir to R700 iron-sight optics
- document optics zoom distances in OpticsInfo

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_68ae057e79888326ae4f079dd59400df